### PR TITLE
Remove sticky positioning from section headings

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -13,7 +13,7 @@ const studies = entries
 
 <section class="max-w-2xl mx-auto px-6 pb-12">
   <div class="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-    <h2 class="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Writing</h2>
+    <h2 class="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Writing</h2>
     <div class="flex flex-col gap-6">
       {
         studies.map((study) => (

--- a/src/components/Experiments.tsx
+++ b/src/components/Experiments.tsx
@@ -32,7 +32,7 @@ const Experiments = () => {
   return (
     <section className="max-w-2xl mx-auto px-6 pb-12">
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-        <h2 className="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Experiments</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Experiments</h2>
         <div className="flex flex-col gap-6">
           {experiments.map((experiment) => (
             <div key={experiment.id}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
   return (
     <footer className="w-full max-w-2xl mx-auto px-6 pb-16">
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1 pb-12">
-        <h2 className="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Connect</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Connect</h2>
         <div className="flex flex-col gap-2 text-gray-600 dark:text-gray-400">
           <a
             href="mailto:&#109;&#97;&#116;&#116;&#64;&#109;&#97;&#116;&#116;&#119;&#104;&#97;&#108;&#108;&#101;&#121;&#46;&#99;&#111;&#109;"
@@ -46,7 +46,7 @@ export default function Footer() {
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-        <h2 className="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Lately</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Lately</h2>
         <div className="flex flex-col gap-2 text-gray-600 dark:text-gray-400 leading-relaxed min-w-0">
           <NowSheet />
           <SpotifyNowPlaying />

--- a/src/components/RecentProjects.tsx
+++ b/src/components/RecentProjects.tsx
@@ -26,7 +26,7 @@ const RecentProjects = () => {
   return (
     <section className="max-w-2xl mx-auto px-6 pb-12">
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-        <h2 className="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Projects</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Projects</h2>
         <div className="flex flex-col gap-6">
           {projects.map((project) => (
             <div key={project.id}>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -34,7 +34,7 @@ const Testimonials = () => {
   return (
     <section className="max-w-2xl mx-auto px-6 pb-12">
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-        <h2 className="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Testimonials</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Testimonials</h2>
         <div className="flex flex-col gap-8">
           {testimonials.map((testimonial) => (
             <div key={testimonial.id}>

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -8,7 +8,7 @@ import CaseStudies from '../components/CaseStudies.astro';
 <main>
   <section class="max-w-2xl mx-auto px-6 pb-12">
     <div class="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
-      <h1 class="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">About</h1>
+      <h1 class="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">About</h1>
       <div class="flex flex-col gap-4 text-gray-700 dark:text-gray-300 leading-relaxed">
         <p>
           I <i class="font-serif italic text-[1.1em] leading-[26px]">solve complex product problems</i> and

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -17,7 +17,7 @@ const studies = entries
     <section class="max-w-2xl mx-auto px-6 pt-12 pb-12">
       <div class="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1">
         <h1
-          class="sticky top-6 self-start bg-white dark:bg-[#181818] font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5"
+          class="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5"
         >
           Writing
         </h1>


### PR DESCRIPTION
## Summary
- Drops `sticky top-6` (and the backdrop color it needed) from the About, Writing, Connect, Lately, Experiments, Testimonials, and Projects section headings
- Keeps `self-start` for grid alignment

## Test plan
- [ ] `pnpm dev` and scroll the homepage/footer/case-studies index to confirm headings scroll normally instead of sticking

🤖 Generated with [Claude Code](https://claude.com/claude-code)