### PR TITLE
Rework footer downloads and projects list

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,15 +16,6 @@ export default function Footer() {
             <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
           </a>
           <a
-            href="https://github.com/mttwhlly"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-baseline gap-1.5 w-fit hover:underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
-          >
-            GitHub
-            <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
-          </a>
-          <a
             href="https://linkedin.com/in/mttwhlly"
             target="_blank"
             rel="noopener noreferrer"
@@ -33,11 +24,20 @@ export default function Footer() {
             LinkedIn
             <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
           </a>
+          <a
+            href="https://github.com/mttwhlly"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-baseline gap-1.5 w-fit hover:underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
+          >
+            GitHub
+            <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
+          </a>
         </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-x-6 gap-y-2 sm:gap-y-1 pb-12">
-        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Experience</h2>
+        <h2 className="self-start font-mono text-sm text-gray-500 dark:text-gray-400 pt-0.5">Downloads</h2>
         <div className="flex flex-col gap-2 text-gray-600 dark:text-gray-400">
           <a
             href="/matt-whalley-resume.pdf"
@@ -48,6 +48,33 @@ export default function Footer() {
             Resume
             <ArrowDown size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
           </a>
+          <a
+            href="/matt-whalley-user-manual.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-baseline gap-1.5 w-fit hover:underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
+          >
+            User Manual
+            <ArrowDown size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
+          </a>
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <a
+              href="https://github.com/mttwhlly/sui-sans/raw/refs/heads/main/Sui-Regular.otf"
+              download
+              className="inline-flex items-baseline gap-1.5 w-fit hover:underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
+            >
+              Sui Sans Typeface
+              <ArrowDown size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
+            </a>
+            <a
+              href="https://github.com/mttwhlly/sui-sans"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-fit text-sm text-gray-400 dark:text-gray-500 hover:underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
+            >
+              (Source)
+            </a>
+          </div>
         </div>
       </div>
 

--- a/src/components/RecentProjects.tsx
+++ b/src/components/RecentProjects.tsx
@@ -5,8 +5,8 @@ const RecentProjects = () => {
   const projects = [
     {
       id: 4,
-      title: 'Figma RFD Checker',
-      description: 'Catches design handoff issues before they reach development.',
+      title: 'Figma RFD Plugin',
+      description: 'Catches design handoff issues before devs (or agents) code.',
       liveUrl: 'https://www.figma.com/community/plugin/1621901729405123866',
     },
     {
@@ -16,10 +16,10 @@ const RecentProjects = () => {
       liveUrl: 'https://canisurf.today',
     },
     {
-      id: 5,
-      title: 'Sui Sans Typeface',
-      description: 'Typeface inspired by the lettering of vintage stereo equipment.',
-      liveUrl: 'https://github.com/mttwhlly/sui-sans',
+      id: 2,
+      title: 'Hang Lab',
+      description: 'iOS/WatchOS hangboard training app for climbers.',
+      note: 'Currently being rebuilt in React Native for cross-platform — reach out for details.',
     },
   ];
 
@@ -30,16 +30,23 @@ const RecentProjects = () => {
         <div className="flex flex-col gap-6">
           {projects.map((project) => (
             <div key={project.id}>
-              <a
-                href={project.liveUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-baseline gap-1.5 text-gray-900 dark:text-gray-100 hover:underline underline-offset-2"
-              >
-                {project.title}
-                <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
-              </a>
+              {project.liveUrl ? (
+                <a
+                  href={project.liveUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-baseline gap-1.5 text-gray-900 dark:text-gray-100 hover:underline underline-offset-2"
+                >
+                  {project.title}
+                  <ArrowUpRight size={12} weight="bold" className="text-gray-400 dark:text-gray-500" />
+                </a>
+              ) : (
+                <span className="text-gray-900 dark:text-gray-100">{project.title}</span>
+              )}
               <p className="text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">{project.description}</p>
+              {project.note && (
+                <p className="text-gray-400 dark:text-gray-500 text-sm italic mt-0.5">{project.note}</p>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Reorder Connect links (LinkedIn above GitHub)
- Rename "Experience" to "Downloads"; add User Manual and Sui Sans OTF download with a separate GitHub source link
- Rename Figma RFD Checker to Figma RFD Plugin and update its blurb to mention agents alongside human devs
- Re-add Hang Lab as a project (no live link, since TestFlight has expired; note points to the in-progress React Native rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)