### PR TITLE
Remove Layer N prefixes from case study headings

### DIFF
--- a/src/content/case-studies/enterprise-design-system.mdx
+++ b/src/content/case-studies/enterprise-design-system.mdx
@@ -54,7 +54,7 @@ That sequence is the reusable part.
 
 ---
 
-## Layer 1: You can’t manage what you can only estimate
+## You can’t manage what you can only estimate
 
 The starting question sounded simple:
 
@@ -115,7 +115,7 @@ if (badFiles.length) {
 
 ---
 
-## Layer 2: “Unmapped” was hiding five different problems
+## “Unmapped” was hiding five different problems
 
 Once measurement was trustworthy, the next disorder was conceptual.
 
@@ -176,7 +176,7 @@ Committed team-wide totals from a clean run (`agent/coverage-team.json`):
 
 ---
 
-## Layer 3: The biggest lever was invisible until the model was right
+## The biggest lever was invisible until the model was right
 
 Once the categories existed, the priority order stopped being guesswork.
 
@@ -224,7 +224,7 @@ const toMuiExport = (figmaName) =>
 
 ---
 
-## Layer 4: Coverage had to mean “safe to act on”
+## Coverage had to mean “safe to act on”
 
 One of the most important parts of the project was deciding what not to count.
 
@@ -252,7 +252,7 @@ So the coverage number had to become less like a dashboard metric and more like 
 
 ---
 
-## Layer 5: Forks were not code problems
+## Forks were not code problems
 
 After the mapping and denominator work, one of the biggest remaining categories was forked components.
 
@@ -300,7 +300,7 @@ if (setNode.key === entry.key) {
 
 ---
 
-## Layer 6: Mapping is not distribution
+## Mapping is not distribution
 
 A Figma-to-code mapping that only works inside Figma validation is not yet infrastructure.
 
@@ -359,7 +359,7 @@ import { AppProviders } from '@org/design-system/providers';
 
 ---
 
-## Layer 7: Order has to survive after you leave the room
+## Order has to survive after you leave the room
 
 The last layer was durability.
 


### PR DESCRIPTION
## Summary
- Removes "Layer N: " prefixes from the seven section headings in the enterprise design system case study, keeping the substantive part of each heading.

## Test plan
- Visual check of the case study page headings render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)