### PR TITLE
Show pause icon in Spotify progress ring when not playing

### DIFF
--- a/.astro/content-modules.mjs
+++ b/.astro/content-modules.mjs
@@ -1,8 +1,8 @@
 
 export default new Map([
-["src/content/case-studies/enterprise-design-system.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fenterprise-design-system.mdx&astroContentModuleFlag=true")],
-["src/content/case-studies/ai-search.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fai-search.mdx&astroContentModuleFlag=true")],
 ["src/content/case-studies/agentic-workflows.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fagentic-workflows.mdx&astroContentModuleFlag=true")],
+["src/content/case-studies/ai-search.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fai-search.mdx&astroContentModuleFlag=true")],
+["src/content/case-studies/enterprise-design-system.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fenterprise-design-system.mdx&astroContentModuleFlag=true")],
 ["src/content/case-studies/ai-native-judgment.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Fai-native-judgment.mdx&astroContentModuleFlag=true")],
 ["src/content/case-studies/false-positive-rates.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fcase-studies%2Ffalse-positive-rates.mdx&astroContentModuleFlag=true")]]);
 		

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -47,6 +47,12 @@ export default function CircularProgress({
           className="text-gray-900 dark:text-gray-100"
         />
       )}
+      {muted && (
+        <g transform={`rotate(90 ${size / 2} ${size / 2})`} className="fill-gray-400 dark:fill-neutral-500">
+          <rect x={size / 2 - 2.3} y={size / 2 - 3} width="1.6" height="6" rx="0.4" />
+          <rect x={size / 2 + 0.7} y={size / 2 - 3} width="1.6" height="6" rx="0.4" />
+        </g>
+      )}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a small pause icon inside the circular progress ring in the Spotify now-playing widget when a track isn't currently playing, alongside the existing "(Xh ago)" label

## Test plan
- [x] `pnpm build` succeeds
- [x] Verified icon geometry/legibility at actual 18px size via isolated SVG render